### PR TITLE
Fix key import via URL when Internet Explorer engine is not available

### DIFF
--- a/library/win_authorized_key.ps1
+++ b/library/win_authorized_key.ps1
@@ -549,14 +549,14 @@ function enforce_state {
         }
 
         try {
-            $resp = invoke-webrequest -method head -uri $key
+            $resp = invoke-webrequest -method head -uri $key -UseBasicParsing
             $statusCode = $resp.statuscode
             if ($statusCode -ne 200) {
                 $result = @{ }
                 Fail-Json -obj $result -Message ($LocalizedData.ErrorGettingKeyFrom -f $key);
             }
             else {
-                $wrq = (invoke-webrequest -uri $key -Method Get)
+                $wrq = (invoke-webrequest -uri $key -Method Get -UseBasicParsing)
                 $content = $wrq.Content
                 $encoding = $null
                 # http://en.wikipedia.org/wiki/Mime_type


### PR DESCRIPTION
Description
===========

I had an error running the role to setup auth keys with github key urls. After tweeking the code to print the exception message instead of the generic error I received this error:

```
The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.
```

I tried it and it works. So this patch just makes sure to use `-UseBasicParsing` flag in the `invoke-webrequest` calls.